### PR TITLE
feat: expose tools.invoke adapter fallback

### DIFF
--- a/docs/gateway-rpc-gap-map.md
+++ b/docs/gateway-rpc-gap-map.md
@@ -20,16 +20,18 @@ This maps the current SDK shape to Gateway methods so we can help Peter by valid
 | `oc.approvals.list()` | Pending exec approvals | `exec.approval.list` | Works today | Exec only today. |
 | `oc.approvals.respond()` | Resolve approval | `exec.approval.resolve` | Works today | May need unified exec/plugin approval facade. |
 | plugin approvals | Tool/plugin approval flow | `plugin.approval.*` | Gateway exists | SDK facade should normalize with exec approvals. |
-| `oc.tools.invoke()` | Generic app tool invocation | Proposed `tools.invoke` RPC | Missing | There is HTTP `/tools/invoke`, but SDK wants a clean Gateway RPC. |
+| `oc.tools.invoke()` | Generic app tool invocation | `tools.invoke` | Implemented upstream | Implemented by OpenClaw PR #74804 / issue #74705. OpenMeow adapter exposes it as `invokeTool()` and falls back to HTTP `/tools/invoke` for older installed Gateways that still report `unknown method`. |
 | `oc.tasks.list/get/cancel()` | Detached task ledger | Proposed `tasks.*` RPC | Missing/scaffolded | Background tasks exist conceptually, but SDK API throws unsupported. |
 | `oc.artifacts.list/get/download()` | Files/media/diffs/logs | Proposed `artifacts.*` RPC | Missing/scaffolded | Critical for rich OpenMeow results later. |
 | `oc.environments.*` | Local/node/managed execution envs | Proposed `environments.*` RPC | Missing/scaffolded | Good design target; should stay explicit unsupported for now. |
 
 ## Suggested next Gateway RPCs
 
-### `tools.invoke`
+### `tools.invoke` — implemented upstream
 
 A Gateway RPC equivalent of HTTP `/tools/invoke`, with the same policy and approval semantics.
+
+Status: implemented upstream by OpenClaw PR #74804 for issue #74705 and exposed through `oc.tools.invoke()`. OpenMeow keeps a temporary HTTP fallback because live installed Gateways may lag current OpenClaw main and return `unknown method: tools.invoke`.
 
 ```ts
 type ToolsInvokeParams = {

--- a/docs/openmeow-sdk-adapter-shape.md
+++ b/docs/openmeow-sdk-adapter-shape.md
@@ -27,6 +27,13 @@ interface OpenMeowSDKClient {
   wait(runId: string, timeoutMs?: number): Promise<unknown>;
   cancel(runId: string, sessionKey: string): Promise<unknown>;
   effectiveTools(sessionKey?: string): Promise<unknown>;
+  invokeTool(name: string, params?: {
+    args?: Record<string, unknown>;
+    sessionKey?: string;
+    agentId?: string;
+    confirm?: boolean;
+    idempotencyKey?: string;
+  }): Promise<unknown>;
 }
 ```
 
@@ -43,6 +50,7 @@ interface OpenMeowSDKClient {
 | `wait` | `oc.runs.wait(runId, { timeoutMs })` |
 | `cancel` | `oc.runs.cancel(runId, sessionKey)` |
 | `effectiveTools` | `oc.tools.effective({ sessionKey })` |
+| `invokeTool` | `oc.tools.invoke(name, params)` |
 
 ## Local implementation
 
@@ -56,6 +64,7 @@ It intentionally depends only on the public `@openclaw/sdk` package boundary:
 - `reduceOpenMeowRunState()` and `markOpenMeowRunCancelling()` implement the send-or-stop composer state.
 - `reduceOpenMeowCancelResult()` maps the immediate cancel/abort response into deterministic UI recovery while the live Gateway wait/cancel contract is clarified.
 - `normalizeOpenMeowWaitResult()` separates a wait deadline (`status: "accepted"`) from a runtime timeout (`status: "timed_out"`).
+- `invokeTool()` wraps the SDK-facing Gateway `tools.invoke` RPC added upstream in OpenClaw PR #74804, with a temporary HTTP `/tools/invoke` fallback for installed Gateways that still return `unknown method: tools.invoke`.
 
 ## UI state guarantees OpenMeow wants
 

--- a/docs/prioritized-backlog.md
+++ b/docs/prioritized-backlog.md
@@ -38,9 +38,11 @@ Acceptance:
 
 ## P1 — Gateway RPC gaps
 
-### 4. Add SDK-style `tools.invoke` RPC
+### 4. Add SDK-style `tools.invoke` RPC — done upstream
 
 **Why:** HTTP `/tools/invoke` exists, but SDK needs a Gateway RPC method with the same policy semantics.
+
+Status: implemented upstream by OpenClaw PR #74804 for issue #74705; this repo's adapter exposes it as `invokeTool()` with a temporary HTTP fallback for older installed Gateways.
 
 Acceptance:
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,6 +15,14 @@ export type OpenMeowRunRef = {
   sessionKey: string;
 };
 
+export type OpenMeowToolInvokeParams = {
+  args?: Record<string, unknown>;
+  sessionKey?: string;
+  agentId?: string;
+  confirm?: boolean;
+  idempotencyKey?: string;
+};
+
 export type OpenMeowRunState = {
   mode: "idle" | "streaming" | "cancelling";
   activeRun: OpenMeowRunRef | null;
@@ -108,6 +116,7 @@ export type OpenMeowSDKClient = {
   wait(runId: string, timeoutMs?: number): Promise<unknown>;
   cancel(runId: string, sessionKey: string): Promise<unknown>;
   effectiveTools(sessionKey?: string): Promise<unknown>;
+  invokeTool(name: string, params?: OpenMeowToolInvokeParams): Promise<unknown>;
 };
 
 export type OpenMeowSDKClientOptions = {

--- a/src/index.js
+++ b/src/index.js
@@ -147,6 +147,78 @@ async function loadOpenClawFromSdk(options) {
   });
 }
 
+function isMissingToolsInvokeRpc(error) {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return (
+    message.includes("unknown method: tools.invoke") ||
+    message.includes("OpenClaw SDK client does not expose tools.invoke()") ||
+    message.includes("oc.tools.invoke is not supported")
+  );
+}
+
+function resolveGatewayHttpUrl(options) {
+  const rawGateway = options.gateway ?? process.env.OPENCLAW_GATEWAY_URL;
+  if (typeof rawGateway !== "string" || !rawGateway.trim() || rawGateway === "auto") {
+    throw new Error("OpenMeow HTTP tool fallback requires an explicit Gateway URL");
+  }
+  const url = new URL(rawGateway);
+  if (url.protocol === "ws:") {
+    url.protocol = "http:";
+  } else if (url.protocol === "wss:") {
+    url.protocol = "https:";
+  }
+  url.pathname = "/tools/invoke";
+  url.search = "";
+  url.hash = "";
+  return url;
+}
+
+function resolveHttpBearer(options) {
+  return (
+    options.password ??
+    process.env.OPENCLAW_GATEWAY_PASSWORD ??
+    options.token ??
+    process.env.OPENCLAW_GATEWAY_TOKEN
+  );
+}
+
+async function invokeToolOverHttp(options, name, params) {
+  if (params.confirm === true) {
+    throw new Error("OpenMeow HTTP tool fallback does not support confirm: true approvals");
+  }
+  const url = resolveGatewayHttpUrl(options);
+  const headers = { "Content-Type": "application/json" };
+  const bearer = resolveHttpBearer(options);
+  if (typeof bearer === "string" && bearer.trim()) {
+    headers.Authorization = `Bearer ${bearer}`;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      tool: name,
+      args: params.args,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      idempotencyKey: params.idempotencyKey,
+    }),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (response.ok && body?.ok === true) {
+    return { ok: true, toolName: name, output: body.result, source: "http" };
+  }
+  return {
+    ok: false,
+    toolName: name,
+    source: "http",
+    error: {
+      code: body?.error?.type ?? `http_${response.status}`,
+      message: body?.error?.message ?? response.statusText ?? "tool invocation failed",
+    },
+  };
+}
+
 export function createOpenMeowSDKClient(options = {}) {
   let openClaw = options.openClaw;
 
@@ -267,6 +339,25 @@ export function createOpenMeowSDKClient(options = {}) {
       }
       const params = typeof sessionKey === "string" && sessionKey.trim() ? { sessionKey } : {};
       return oc.tools.effective(params);
+    },
+
+    async invokeTool(name, params = {}) {
+      const toolName = assertNonEmptyString(name, "name");
+      if (!isObject(params)) {
+        throw new TypeError("params must be an object");
+      }
+      const oc = await getOpenClaw();
+      if (!oc.tools || typeof oc.tools.invoke !== "function") {
+        return await invokeToolOverHttp(options, toolName, params);
+      }
+      try {
+        return await oc.tools.invoke(toolName, params);
+      } catch (error) {
+        if (!isMissingToolsInvokeRpc(error)) {
+          throw error;
+        }
+        return await invokeToolOverHttp(options, toolName, params);
+      }
     },
   };
 }

--- a/test/openmeow-sdk-client.test.js
+++ b/test/openmeow-sdk-client.test.js
@@ -89,6 +89,10 @@ function makeFakeOpenClaw() {
         calls.push(["tools.effective", params]);
         return { tools: [], params };
       },
+      async invoke(name, params) {
+        calls.push(["tools.invoke", name, params]);
+        return { ok: true, toolName: name, output: { invoked: true } };
+      },
     },
   };
 }
@@ -124,6 +128,15 @@ describe("OpenMeow SDK adapter", () => {
       tools: [],
       params: { sessionKey: "session:cody" },
     });
+    assert.deepEqual(
+      await client.invokeTool("demo", {
+        args: { mode: "test" },
+        sessionKey: sent.sessionKey,
+        confirm: false,
+        idempotencyKey: "openmeow-tool-test",
+      }),
+      { ok: true, toolName: "demo", output: { invoked: true } },
+    );
     await client.close();
 
     assert.deepEqual(openClaw.calls, [
@@ -137,8 +150,104 @@ describe("OpenMeow SDK adapter", () => {
       ["runs.wait", "run_1", { timeoutMs: 30_000 }],
       ["runs.cancel", "run_1", "session:cody"],
       ["tools.effective", { sessionKey: "session:cody" }],
+      [
+        "tools.invoke",
+        "demo",
+        {
+          args: { mode: "test" },
+          sessionKey: "session:cody",
+          confirm: false,
+          idempotencyKey: "openmeow-tool-test",
+        },
+      ],
       ["close"],
     ]);
+  });
+
+  it("fails clearly when direct tool invocation is unavailable and no HTTP fallback is configured", async () => {
+    const client = createOpenMeowSDKClient({ openClaw: { tools: {} } });
+
+    await assert.rejects(
+      client.invokeTool("demo", { args: {} }),
+      /HTTP tool fallback requires an explicit Gateway URL/,
+    );
+  });
+
+  it("falls back to HTTP /tools/invoke when the live Gateway does not advertise tools.invoke yet", async () => {
+    const previousFetch = globalThis.fetch;
+    const requests = [];
+    globalThis.fetch = async (url, init) => {
+      requests.push({
+        url: String(url),
+        method: init.method,
+        authorization: init.headers.Authorization,
+        body: JSON.parse(init.body),
+      });
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { ok: true, result: { desktop: "ok" } };
+        },
+      };
+    };
+
+    try {
+      const client = createOpenMeowSDKClient({
+        gateway: "ws://127.0.0.1:18789",
+        token: "token-secret",
+        password: "password-secret",
+        openClaw: {
+          tools: {
+            async invoke() {
+              throw new Error("unknown method: tools.invoke");
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(
+        await client.invokeTool("desktop_use", {
+          args: { action: "doctor" },
+          sessionKey: "agent:cody:main",
+          idempotencyKey: "desktop-doctor",
+        }),
+        { ok: true, toolName: "desktop_use", output: { desktop: "ok" }, source: "http" },
+      );
+      assert.deepEqual(requests, [
+        {
+          url: "http://127.0.0.1:18789/tools/invoke",
+          method: "POST",
+          authorization: "Bearer password-secret",
+          body: {
+            tool: "desktop_use",
+            args: { action: "doctor" },
+            sessionKey: "agent:cody:main",
+            idempotencyKey: "desktop-doctor",
+          },
+        },
+      ]);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  it("does not use HTTP fallback for confirm:true tool approvals", async () => {
+    const client = createOpenMeowSDKClient({
+      gateway: "ws://127.0.0.1:18789",
+      openClaw: {
+        tools: {
+          async invoke() {
+            throw new Error("unknown method: tools.invoke");
+          },
+        },
+      },
+    });
+
+    await assert.rejects(
+      client.invokeTool("desktop_use", { confirm: true }),
+      /HTTP tool fallback does not support confirm: true/,
+    );
   });
 
   it("supports current SDK handle objects that expose async agents.get(), Session.key, and Run.id", async () => {


### PR DESCRIPTION
## Summary
- add OpenMeow adapter invokeTool(name, params) over the OpenClaw SDK tools.invoke API
- fall back to HTTP /tools/invoke when a live installed Gateway still returns unknown method: tools.invoke
- document that OpenClaw PR #74804 / issue #74705 implements the upstream RPC while OpenMeow keeps a temporary installed-Gateway compatibility path

## Notes
- Refs #4
- HTTP fallback prefers password-style bearer auth before token-style auth, matching the latest live OpenMeow SDK validation note.
- HTTP fallback refuses confirm: true because approval-request semantics are not equivalent on the fallback path.

## Validation
- npm test
- git diff --check HEAD