### PR TITLE
Expose OpenClaw environment discovery in adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ This repo now includes the first local P0 dogfood adapter implementation:
 
 - `src/index.js` — OpenMeow-side adapter over `@openclaw/sdk` plus UI event/lane-state/run-state helpers.
 - `src/index.d.ts` — app-facing TypeScript types.
-- `test/openmeow-sdk-client.test.js` — Node test coverage for agents/sessions/runs, normalized UI events, wait deadlines, and stop-button state.
+- `test/openmeow-sdk-client.test.js` — Node test coverage for agents/sessions/runs, tools, read-only environment discovery, normalized UI events, wait deadlines, and stop-button state.
 
 No OpenClaw core changes live here.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,7 +197,7 @@ flowchart LR
   Ephemeral --> Gateway
 ```
 
-Current SDK should reject unsupported runtime/environment/workspace fields explicitly rather than silently ignoring them. That behavior is good and should remain until Gateway support is real.
+Current SDK can discover environments read-only through `environments.list/status`, but run-level runtime/environment/workspace selection and provisioning should still reject unsupported fields explicitly rather than silently ignoring them.
 
 ## 6. OpenMeow module cut
 

--- a/docs/gateway-rpc-gap-map.md
+++ b/docs/gateway-rpc-gap-map.md
@@ -23,7 +23,7 @@ This maps the current SDK shape to Gateway methods so we can help Peter by valid
 | `oc.tools.invoke()` | Generic app tool invocation | `tools.invoke` | Implemented upstream | Implemented by OpenClaw PR #74804 / issue #74705. OpenMeow adapter exposes it as `invokeTool()` and falls back to HTTP `/tools/invoke` for older installed Gateways that still report `unknown method`. |
 | `oc.tasks.list/get/cancel()` | Detached task ledger | Proposed `tasks.*` RPC | Missing/scaffolded | Background tasks exist conceptually, but SDK API throws unsupported. |
 | `oc.artifacts.list/get/download()` | Files/media/diffs/logs | Proposed `artifacts.*` RPC | Missing/scaffolded | Critical for rich OpenMeow results later. |
-| `oc.environments.*` | Local/node/managed execution envs | Proposed `environments.*` RPC | Missing/scaffolded | Good design target; should stay explicit unsupported for now. |
+| `oc.environments.list/status()` | Local/node/managed execution envs | `environments.list/status` | Implemented upstream | Implemented by OpenClaw PR #74867 / issue #74708. OpenMeow adapter exposes read-only discovery as `listEnvironments()` and `getEnvironmentStatus()`. |
 
 ## Suggested next Gateway RPCs
 
@@ -64,13 +64,13 @@ artifacts.get({ artifactId })
 artifacts.download({ artifactId })
 ```
 
-### `environments.*`
+### `environments.*` — implemented upstream
 
-Start read-only/discovery first:
+Read-only environment discovery is implemented upstream by OpenClaw PR #74867 for issue #74708 and exposed by this adapter.
 
 ```ts
 environments.list()
 environments.status({ environmentId })
 ```
 
-Create/delete can follow once managed/node execution semantics are clearer.
+Create/delete and run-level environment provisioning should still wait until managed/node execution semantics are clearer.

--- a/docs/openmeow-sdk-adapter-shape.md
+++ b/docs/openmeow-sdk-adapter-shape.md
@@ -16,6 +16,14 @@ type OpenMeowSendResult = {
   sessionKey: string;
 };
 
+type OpenMeowEnvironmentSummary = {
+  id: string;
+  type: "local" | "gateway" | "node" | "managed" | "ephemeral" | string;
+  label?: string;
+  status: "available" | "unavailable" | "starting" | "stopping" | "error";
+  capabilities?: string[];
+};
+
 interface OpenMeowSDKClient {
   connect(): Promise<void>;
   close(): Promise<void>;
@@ -27,6 +35,8 @@ interface OpenMeowSDKClient {
   wait(runId: string, timeoutMs?: number): Promise<unknown>;
   cancel(runId: string, sessionKey: string): Promise<unknown>;
   effectiveTools(sessionKey?: string): Promise<unknown>;
+  listEnvironments(params?: Record<string, unknown>): Promise<{ environments: OpenMeowEnvironmentSummary[] }>;
+  getEnvironmentStatus(environmentId: string): Promise<OpenMeowEnvironmentSummary>;
   invokeTool(name: string, params?: {
     args?: Record<string, unknown>;
     sessionKey?: string;
@@ -50,6 +60,8 @@ interface OpenMeowSDKClient {
 | `wait` | `oc.runs.wait(runId, { timeoutMs })` |
 | `cancel` | `oc.runs.cancel(runId, sessionKey)` |
 | `effectiveTools` | `oc.tools.effective({ sessionKey })` |
+| `listEnvironments` | `oc.environments.list(params)` |
+| `getEnvironmentStatus` | `oc.environments.status(environmentId)` |
 | `invokeTool` | `oc.tools.invoke(name, params)` |
 
 ## Local implementation
@@ -65,6 +77,7 @@ It intentionally depends only on the public `@openclaw/sdk` package boundary:
 - `reduceOpenMeowCancelResult()` maps the immediate cancel/abort response into deterministic UI recovery while the live Gateway wait/cancel contract is clarified.
 - `normalizeOpenMeowWaitResult()` separates a wait deadline (`status: "accepted"`) from a runtime timeout (`status: "timed_out"`).
 - `invokeTool()` wraps the SDK-facing Gateway `tools.invoke` RPC added upstream in OpenClaw PR #74804, with a temporary HTTP `/tools/invoke` fallback for installed Gateways that still return `unknown method: tools.invoke`.
+- `listEnvironments()` and `getEnvironmentStatus()` wrap the read-only SDK-facing Gateway environment discovery RPCs added upstream in OpenClaw PR #74867.
 
 ## UI state guarantees OpenMeow wants
 

--- a/docs/peter-review-brief.md
+++ b/docs/peter-review-brief.md
@@ -15,7 +15,8 @@ OpenMeow is a good first dogfood client because it stresses the exact product su
 - normalized UI events
 - approvals
 - effective tool visibility
-- future artifacts/tasks/environments
+- read-only environment discovery
+- future artifacts/tasks
 
 ## What is already good
 
@@ -36,7 +37,7 @@ OpenMeow is a good first dogfood client because it stresses the exact product su
 
 4. **Unsupported future options currently fail loudly**
 
-   Runtime/environment/workspace selections are future-facing. Throwing explicit unsupported errors is better than silently dropping those fields.
+   Runtime/workspace selections and environment provisioning are future-facing. Throwing explicit unsupported errors is better than silently dropping those fields.
 
 ## Main concern
 
@@ -58,12 +59,12 @@ The current working core is real:
 - `exec.approval.*`
 - `plugin.approval.*`
 
-But future namespaces are scaffolded ahead of Gateway RPCs:
+Some future namespaces are still scaffolded ahead of Gateway RPCs:
 
 - `tasks.*`
 - `artifacts.*`
-- `environments.*`
-- SDK-style `tools.invoke`
+
+`tools.invoke` and read-only `environments.list/status` are now implemented upstream, so OpenMeow can validate those through the public SDK instead of treating them as design-only surfaces.
 
 That is fine if clearly marked as planned/unsupported, but it should not feel shipped yet.
 
@@ -86,10 +87,9 @@ This is the OpenMeow path:
 
 Add clean RPC methods for SDK-facing future nouns:
 
-- `tools.invoke`
 - `tasks.list/get/cancel`
 - `artifacts.list/get/download`
-- `environments.list/status` first; create/delete later.
+- environment create/delete later, after read-only `environments.list/status` has proven useful.
 
 ### P2 — Validate with OpenMeow
 

--- a/docs/prioritized-backlog.md
+++ b/docs/prioritized-backlog.md
@@ -71,11 +71,11 @@ Start with:
 - `tasks.get`
 - `tasks.cancel`
 
-### 7. Add environment discovery RPCs
+### 7. Add environment discovery RPCs — done upstream
 
 **Why:** managed/node/local environments should be visible before they are creatable.
 
-Start with:
+Status: implemented upstream by OpenClaw PR #74867 for issue #74708; this repo's adapter exposes read-only discovery as `listEnvironments()` and `getEnvironmentStatus()`.
 
 - `environments.list`
 - `environments.status`

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,6 +23,18 @@ export type OpenMeowToolInvokeParams = {
   idempotencyKey?: string;
 };
 
+export type OpenMeowEnvironmentSummary = {
+  id: string;
+  type: "local" | "gateway" | "node" | "managed" | "ephemeral" | (string & {});
+  label?: string;
+  status: "available" | "unavailable" | "starting" | "stopping" | "error";
+  capabilities?: string[];
+};
+
+export type OpenMeowEnvironmentsListResult = {
+  environments: OpenMeowEnvironmentSummary[];
+};
+
 export type OpenMeowRunState = {
   mode: "idle" | "streaming" | "cancelling";
   activeRun: OpenMeowRunRef | null;
@@ -116,6 +128,8 @@ export type OpenMeowSDKClient = {
   wait(runId: string, timeoutMs?: number): Promise<unknown>;
   cancel(runId: string, sessionKey: string): Promise<unknown>;
   effectiveTools(sessionKey?: string): Promise<unknown>;
+  listEnvironments(params?: Record<string, unknown>): Promise<OpenMeowEnvironmentsListResult>;
+  getEnvironmentStatus(environmentId: string): Promise<OpenMeowEnvironmentSummary>;
   invokeTool(name: string, params?: OpenMeowToolInvokeParams): Promise<unknown>;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -341,6 +341,26 @@ export function createOpenMeowSDKClient(options = {}) {
       return oc.tools.effective(params);
     },
 
+    async listEnvironments(params = {}) {
+      if (!isObject(params)) {
+        throw new TypeError("params must be an object");
+      }
+      const oc = await getOpenClaw();
+      if (!oc.environments || typeof oc.environments.list !== "function") {
+        throw new Error("OpenClaw SDK client does not expose environments.list()");
+      }
+      return oc.environments.list(params);
+    },
+
+    async getEnvironmentStatus(environmentId) {
+      const id = assertNonEmptyString(environmentId, "environmentId");
+      const oc = await getOpenClaw();
+      if (!oc.environments || typeof oc.environments.status !== "function") {
+        throw new Error("OpenClaw SDK client does not expose environments.status(environmentId)");
+      }
+      return oc.environments.status(id);
+    },
+
     async invokeTool(name, params = {}) {
       const toolName = assertNonEmptyString(name, "name");
       if (!isObject(params)) {

--- a/test/openmeow-sdk-client.test.js
+++ b/test/openmeow-sdk-client.test.js
@@ -250,6 +250,38 @@ describe("OpenMeow SDK adapter", () => {
     );
   });
 
+  it("exposes OpenClaw environment discovery through the adapter", async () => {
+    const gatewayEnvironment = {
+      id: "gateway",
+      type: "gateway",
+      label: "Local Gateway",
+      status: "available",
+      capabilities: ["runs", "tools"],
+    };
+    const calls = [];
+    const client = createOpenMeowSDKClient({
+      openClaw: {
+        environments: {
+          async list(params) {
+            calls.push(["environments.list", params]);
+            return { environments: [gatewayEnvironment] };
+          },
+          async status(environmentId) {
+            calls.push(["environments.status", environmentId]);
+            return gatewayEnvironment;
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(await client.listEnvironments(), { environments: [gatewayEnvironment] });
+    assert.deepEqual(await client.getEnvironmentStatus("gateway"), gatewayEnvironment);
+    assert.deepEqual(calls, [
+      ["environments.list", {}],
+      ["environments.status", "gateway"],
+    ]);
+  });
+
   it("supports current SDK handle objects that expose async agents.get(), Session.key, and Run.id", async () => {
     const calls = [];
     const client = createOpenMeowSDKClient({


### PR DESCRIPTION
## Summary
- Add OpenMeow adapter methods for read-only environment discovery: `listEnvironments()` and `getEnvironmentStatus(environmentId)`.
- Add TypeScript declarations for environment summaries and list results.
- Refresh current capability docs now that OpenClaw merged `environments.list/status` in openclaw/openclaw#74867 for openclaw/openclaw#74708.

## Notes
- Create/delete and run-level environment provisioning remain unsupported by this adapter.
- Uses existing OpenCoven/open-meow-sdk#7 rather than opening a duplicate compatibility issue.

## Tests
- `npm test`

Closes #7